### PR TITLE
create NetTransport config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ install:
 - go get github.com/mattn/goveralls
 
 script:
-- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./travis/run_on_pull_requests; fi'
-- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./travis/run_on_non_pull_requests; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./travis/run_on_pull_requests.sh; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./travis/run_on_non_pull_requests.sh; fi'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## SWIM: Scalabe Weakly-consistent Infection-style Process Group Membership Protocol 
-[![Build Status](https://travis-ci.org/it-chain/engine.svg?branch=develop)](https://travis-ci.org/it-chain/engine) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Language](https://img.shields.io/badge/language-go-orange.svg)](https://golang.org)
+[![Build Status](https://travis-ci.org/it-chain/engine.svg?branch=develop)](https://travis-ci.org/it-chain/engine) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Language](https://img.shields.io/badge/language-go-orange.svg)](https://golang.org) [![Coverage Status](https://coveralls.io/repos/github/DE-labtory/swim/badge.svg?branch=develop)](https://coveralls.io/github/DE-labtory/swim?branch=develop)
 
 [SWIM Paper](http://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf)
 

--- a/net_transport.go
+++ b/net_transport.go
@@ -1,0 +1,15 @@
+package swim
+
+// PacketTransportConfig is used to configure a net transport
+type PacketTransportConfig struct {
+	// BindAddrs is representing list of address to use for  UDP communication
+	BindAddress string
+
+	// BindPort is the port to listen on. for each address specified above
+	BindPort int
+}
+
+// NetTransport implements Transport interface, which is used ONLY for connectionless UDP packet operations
+type PacketTransport struct {
+	config *PacketTransportConfig
+}


### PR DESCRIPTION
resolved: #25 

details:

I thought that for transport work as expected, transporter necessarily needs address and port.
So both addresses, ports are refactored to NetTransporterConfig
This config fields can be appended later as needed

1. create NetTransporterConfig