### PR TITLE
create packet_transport config

### DIFF
--- a/packet_transport.go
+++ b/packet_transport.go
@@ -1,0 +1,15 @@
+package swim
+
+// PacketTransportConfig is used to configure a udp transport
+type PacketTransportConfig struct {
+	// BindAddrs is representing list of address to use for  UDP communication
+	BindAddress string
+
+	// BindPort is the port to listen on. for each address specified above
+	BindPort int
+}
+
+// PacketTransport implements Transport interface, which is used ONLY for connectionless UDP packet operations
+type PacketTransport struct {
+	config *PacketTransportConfig
+}


### PR DESCRIPTION
resolved: #25

details:

UDPTransport implementation named PacketTransport
(maybe TCPTransport as StreamTransport? @hihiboss suggest..)

I thought that for transport work as expected, transport necessarily needs address and port.
So both address, port are refactored to PacketTransportConfig
This config fields can be appended later as needed

1. create PacketTransportConfig