### PR TITLE
Feature/udp

### DIFF
--- a/packet_transport.go
+++ b/packet_transport.go
@@ -1,15 +1,145 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package swim
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+const (
+	// udpPacketBufSize is used to buffer incoming packets during read
+	// operations.
+	udpPacketBufSize = 65536
+
+	// udpRecvBufSize is a large buffer size that we attempt to set UDP
+	// sockets to in order to handle a large volume of messages.
+	udpRecvBufSize = 2 * 1024 * 1024
+)
 
 // PacketTransportConfig is used to configure a udp transport
 type PacketTransportConfig struct {
-	// BindAddrs is representing list of address to use for  UDP communication
+	// BindAddrs is representing an address to use for UDP communication
 	BindAddress string
 
-	// BindPort is the port to listen on. for each address specified above
+	// BindPort is the port to listen on, for the address specified above
 	BindPort int
 }
 
 // PacketTransport implements Transport interface, which is used ONLY for connectionless UDP packet operations
 type PacketTransport struct {
-	config *PacketTransportConfig
+	config         *PacketTransportConfig
+	packetCh       chan *Packet
+	packetListener *net.UDPConn
+}
+
+func NewPacketTransport(config *PacketTransportConfig) (*PacketTransport, error) {
+	ip := net.ParseIP(config.BindAddress)
+	port := config.BindPort
+
+	udpAddr := &net.UDPAddr{IP: ip, Port: port}
+	udpListener, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to start UDP listener on %s port %d: %v", config.BindAddress, port, err)
+	}
+
+	if err := setUDPRecvBuf(udpListener); err != nil {
+		return nil, fmt.Errorf("Failed to resize UDP buffer: %v", err)
+	}
+
+	t := PacketTransport{
+		config:         config,
+		packetCh:       make(chan *Packet),
+		packetListener: udpListener,
+	}
+
+	go t.listen(t.packetListener)
+
+	return &t, nil
+}
+
+func (t *PacketTransport) WriteTo(b []byte, addr string) (time.Time, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if _, err = t.packetListener.WriteTo(b, udpAddr); err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Now(), nil
+}
+
+func (t *PacketTransport) PacketCh() <-chan *Packet {
+	return t.packetCh
+}
+
+func (t *PacketTransport) Shutdown() error {
+	return t.packetListener.Close()
+}
+
+// udpListen is a long running goroutine that accepts incoming UDP packets and
+// hands them off to the packet channel.
+func (t *PacketTransport) listen(udpListener *net.UDPConn) {
+	for {
+		// Do a blocking read into a fresh buffer. Grab a time stamp as
+		// close as possible to the I/O.
+		buf := make([]byte, udpPacketBufSize)
+		n, addr, err := udpListener.ReadFrom(buf)
+		ts := time.Now()
+
+		if err != nil {
+			fmt.Printf("[ERR] Error reading UDP packet: %v", err)
+			continue
+		}
+
+		// Check the length - it needs to have at least one byte to be a
+		// proper message.
+		if n < 1 {
+			fmt.Printf("[ERR] UDP packet too short (%d bytes) %s", len(buf), addr.String())
+			continue
+		}
+
+		// Ingest the packet.
+		t.packetCh <- &Packet{
+			Buf:       buf[:n],
+			Addr:      addr,
+			Timestamp: ts,
+		}
+	}
+}
+
+// setUDPRecvBuf is used to resize the UDP receive window. The function
+// attempts to set the read buffer to `udpRecvBuf` but backs off until
+// the read buffer can be set.
+func setUDPRecvBuf(c *net.UDPConn) error {
+	size := udpRecvBufSize
+	var err error
+	for size > 0 {
+		// If the read buffer is set, return nil
+		if err = c.SetReadBuffer(size); err == nil {
+			return nil
+		}
+
+		// If the read buffer size is large, back off.
+		// Because smaller size will be more easy to set to read buffer.
+		size = size / 2
+	}
+	return err
 }

--- a/packet_transport.go
+++ b/packet_transport.go
@@ -1,0 +1,15 @@
+package swim
+
+// PacketTransportConfig is used to configure a udp transport
+type PacketTransportConfig struct {
+	// BindAddrs is representing list of address to use for  UDP communication
+	BindAddress string
+
+	// BindPort is the port to listen on. for each address specified above
+	BindPort int
+}
+
+// PacketTransport implements Transport interface, which is used ONLY for connectionless UDP packet operations
+type PacketTransport struct {
+	config *PacketTransportConfig
+}

--- a/packet_transport.go
+++ b/packet_transport.go
@@ -19,8 +19,8 @@ package swim
 import (
 	"fmt"
 	"net"
-	"time"
 	"sync"
+	"time"
 )
 
 const (
@@ -122,7 +122,7 @@ func (t *PacketTransport) listen() {
 		n, addr, err := t.packetListener.ReadFrom(buf)
 		ts := time.Now()
 
-		if t.isShutDown {
+		if t.checkShutDown() {
 			break
 		}
 
@@ -145,6 +145,13 @@ func (t *PacketTransport) listen() {
 			Timestamp: ts,
 		}
 	}
+}
+
+func (t *PacketTransport) checkShutDown() bool {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.isShutDown
 }
 
 // setUDPRecvBuf is used to resize the UDP receive window. The function

--- a/packet_transport_internal_test.go
+++ b/packet_transport_internal_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package swim
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPacketTransport_listen(t *testing.T) {
+	// given
+	c := PacketTransportConfig{
+		BindAddress: "127.0.0.1",
+		BindPort:    1234,
+	}
+
+	// when
+	p, err := NewPacketTransport(&c)
+	assert.Nil(t, err)
+
+	p.WriteTo([]byte{'a'}, "127.0.0.1:1234")
+
+	// then
+	packet := <-p.packetCh
+	assert.NotNil(t, packet)
+}

--- a/packet_transport_internal_test.go
+++ b/packet_transport_internal_test.go
@@ -18,6 +18,7 @@ package swim
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/packet_transport_test.go
+++ b/packet_transport_test.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package swim_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/DE-labtory/swim"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPacketListener(t *testing.T) {
+	// given
+	ip := net.ParseIP("127.0.0.1")
+	port := 12345
+
+	// when
+	l, err := swim.NewPacketListener(ip, port)
+
+	// then
+	assert.NotNil(t, l)
+	assert.NoError(t, err)
+
+	l.Close()
+}
+
+func TestNewPacketTransport(t *testing.T) {
+	// given
+	c := swim.PacketTransportConfig{
+		BindAddress: "127.0.0.1",
+		BindPort:    12345,
+	}
+
+	// when
+	p, err := swim.NewPacketTransport(&c)
+
+	// then
+	assert.NotNil(t, p)
+	assert.NoError(t, err)
+
+	p.Shutdown()
+}
+
+func TestPacketTransport_PacketCh(t *testing.T) {
+	// given
+	c := swim.PacketTransportConfig{
+		BindAddress: "127.0.0.1",
+		BindPort:    12345,
+	}
+
+	p, err := swim.NewPacketTransport(&c)
+	assert.NotNil(t, p)
+	assert.NoError(t, err)
+
+	time, err := p.WriteTo([]byte{'a'}, "127.0.0.1:12345")
+	assert.NotNil(t, time)
+	assert.NoError(t, err)
+
+	// when
+	packet := <-p.PacketCh()
+
+	// then
+	assert.NotNil(t, packet)
+	assert.Equal(t, []byte{'a'}, packet.Buf)
+	assert.NotEqual(t, []byte{'b'}, packet.Buf)
+
+	p.Shutdown()
+}
+
+func TestPacketTransport_WriteTo(t *testing.T) {
+	// given
+	c := swim.PacketTransportConfig{
+		BindAddress: "127.0.0.1",
+		BindPort:    12345,
+	}
+
+	p, err := swim.NewPacketTransport(&c)
+	assert.NotNil(t, p)
+	assert.NoError(t, err)
+
+	// when
+	time, err := p.WriteTo([]byte{'a'}, "127.0.0.1:12345")
+
+	// then
+	assert.NotNil(t, time)
+	assert.NoError(t, err)
+
+	p.Shutdown()
+}
+
+func TestPacketTransport_Shutdown(t *testing.T) {
+	// given
+	c := swim.PacketTransportConfig{
+		BindAddress: "127.0.0.1",
+		BindPort:    12345,
+	}
+
+	p, err := swim.NewPacketTransport(&c)
+	assert.NotNil(t, p)
+	assert.NoError(t, err)
+
+	// when
+	err = p.Shutdown()
+
+	// then
+	assert.NoError(t, err)
+	_, err = p.WriteTo([]byte{'a'}, "127.0.0.1:12345")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
resolved: #25

details:

UDPTransport implementation named PacketTransport
(maybe TCPTransport as StreamTransport? @hihiboss suggest..)

I thought that for transport work as expected, transport necessarily needs address and port.
So both address, port are refactored to PacketTransportConfig
This config fields can be appended later as needed

1. create PacketTransportConfig
---
resolved: #29 

details:

Implemented PacketTransport. But I need some help or suggestion of you!

**Check Please**
- [x] `type PacketTransport struct` is ok?
- [x] `func NewPacketTransport` is ok?
- [x] `func WriteTo` is ok?
- [x] `func PacketCh` is ok?
- [x] `func Shutdown` is ok?
- [x] `func listen` is ok?
- [x] `func setUDPRecvBuf` is ok?
- [x] I omitted lock (`wg sync.WaitGroup`, shutdown int 32`, `atomic.LoadInt32/atomic.StoreInt32`, ... )

1. Create PacketTransport
2. Implemented functions ofPacketTransport

- [x] Test case