### PR TITLE
Implement interface and some functions of Piggyback store for efficient dissemination

### DIFF
--- a/pbkstore.go
+++ b/pbkstore.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package swim
+
+import "sync"
+
+// PiggyBackData consists of data and localCount.
+// The localCount is incremented each time the data is queried.
+// The lower the localCount, the faster the queried.
+// The data has a member status, such as alive, suspected or dead.
+type piggyBackData struct {
+	data       []byte
+	localCount int
+}
+
+// PiggyBackStore store a piggyback data. When we ping, ack or indirect-ack,
+// get PiggyBackData from the PiggyBackStore and send it with ping, ack or indirect-ack.
+type PiggyBackStore interface {
+	Len() int
+	Push(b []byte) error
+	Get() ([]byte, error)
+	IsEmpty() bool
+}
+
+// PiggyBackPriorityStore stores piggyback data and returns data with small local count.
+type PiggyBackPriorityStore struct {
+	list    []piggyBackData
+	maxSize int
+	lock    sync.RWMutex
+}
+
+func NewPiggyBackPriorityStore(maxSize int) *PiggyBackPriorityStore {
+	return &PiggyBackPriorityStore{
+		list:    make([]piggyBackData, 0),
+		maxSize: maxSize,
+		lock:    sync.RWMutex{},
+	}
+}
+
+// Return current size of data
+func (p *PiggyBackPriorityStore) Len() int {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	return len(p.list)
+}
+
+// Enqueue []byte into list.
+// Initially, set the local count to zero.
+// If the queue size is max, delete the data with the highest localcount and insert it.
+func (p *PiggyBackPriorityStore) Push(b []byte) error {
+	return nil
+}
+
+// Return the piggyback data with the smallest local count in the list,
+// increment the local count and sort it again, not delete the data.
+func (p *PiggyBackPriorityStore) Get() ([]byte, error) {
+	return nil, nil
+}
+
+func (p *PiggyBackPriorityStore) IsEmpty() bool {
+	return true
+}


### PR DESCRIPTION
resolved: #33

**Details:**
The following description was taken from #33.

```
Implement Infection-style dissemination mechanism (ref https://github.com/DE-labtory/swim/blob/develop/docs/Docs.md)

각 그룹의 멤버 M_i는 버퍼를 가지고 있는데

버퍼에는 최근에 발생한 membership update 정보들을 담고 있다.
그리고 버퍼에 자신(M_i)이 주위 멤버들에게 piggyback한 횟수를 담고 있는 local count의 정보를 담는다. 그리고 이 local count로 자신이 다음에 누구에게 piggyback 할지를 결정할 수 있다.
버퍼의 사이즈가 한 멤버가 ping (또는 ack)을 piggyback 할 수 있는 최대 횟수보다 크다면(충분히 크다면) 다음으로 piggyback 할 멤버는 local count가 작은 멤버로 한다.
그리고 두 개의 그룹 멤버 리스트를 가지고 있다.

하나에는 아직 그룹에서 “failed” 되지 않은 멤버들을 담고 있고
다른 하나에는 현재 “failed” 된 멤버들을 담고 있다.
```

I implemented the `buffer` described in the previous article as a `piggyback store` and implemented it to store piggyback data rather than having two group members. The `piggyback store` can contain various data about member updates (alive, suspected, dead).
If there is a change in status in my memberlist, it is stored the new status in the piggyback store. Every time I send a ping, ack, or indirect-ping, dequeue from the piggyback store and sends with ping, ack, or indirect-ping

**Tasks:**
1. Define interface of piggyback store 
2. Implement some functions of piggyback store 