### PR TITLE
Pbkstore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/DE-labtory/swim
 
-require github.com/urfave/cli v1.20.0
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
+	github.com/stretchr/testify v1.2.2
+	github.com/urfave/cli v1.20.0
+)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/DE-labtory/swim
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/magiconair/properties v1.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2

--- a/heap.go
+++ b/heap.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package swim
+
+import "container/heap"
+
+// I modified and updated the example at https://golang.org/pkg/container/heap/ (@junbeomlee)
+
+// An Item is something we manage in a priority queue.
+type Item struct {
+	value    interface{} // The value of the item; arbitrary.
+	priority int         // The priority of the item in the queue.
+	// The index is needed by update and is maintained by the heap.Interface methods.
+	index int // The index of the item in the heap.
+}
+
+// A PriorityQueue implements heap.Interface and holds Items.
+type PriorityQueue []*Item
+
+// Return length of priority queue
+func (pq PriorityQueue) Len() int { return len(pq) }
+
+// We want Pop to give us the lowest, not highest, priority so we use lower than here.
+func (pq PriorityQueue) Less(i, j int) bool {
+
+	return pq[i].priority < pq[j].priority
+}
+
+// We want Pop to give us the lowest, not highest, priority so we use lower than here.
+func (pq PriorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *PriorityQueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*Item)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+// Pop item from last
+func (pq *PriorityQueue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	item := old[n-1]
+	item.index = -1 // for safety
+	*pq = old[0 : n-1]
+
+	return item
+}
+
+// update modifies the priority and value of an Item in the queue.
+func (pq *PriorityQueue) update(item *Item, value interface{}, priority int) {
+	item.value = value
+	item.priority = priority
+	heap.Fix(pq, item.index)
+}

--- a/heap_internal_test.go
+++ b/heap_internal_test.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package swim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Set PriorityQueue
+func setUpHeap(n int) PriorityQueue {
+
+	pq := make(PriorityQueue, 0)
+	for i := 0; i < n; i++ {
+		pq.Push(&Item{
+			value:    i,
+			priority: i,
+			index:    i,
+		})
+	}
+
+	return pq
+}
+
+func TestPriorityQueue_Len(t *testing.T) {
+	heapSize := 3
+
+	q := setUpHeap(heapSize)
+	assert.Equal(t, q.Len(), heapSize)
+}
+
+func TestPriorityQueue_Less(t *testing.T) {
+	heapSize := 3
+
+	// q item priority will be [0, 1, 2]
+	q := setUpHeap(heapSize)
+
+	// 0 will be lower then 1
+	assert.True(t, q.Less(0, 1))
+
+	// 1 will be lower then 2
+	assert.True(t, q.Less(1, 2))
+
+	// 0 will be lower then 2
+	assert.True(t, q.Less(0, 1))
+}
+
+func TestPriorityQueue_Pop(t *testing.T) {
+	heapSize := 3
+
+	// q item value will be [0, 1, 2]
+	// Pop function will pop item from tail
+	q := setUpHeap(heapSize)
+
+	assert.Equal(t, 2, q.Pop().(*Item).value)
+	assert.Equal(t, 1, q.Pop().(*Item).value)
+	assert.Equal(t, 0, q.Pop().(*Item).value)
+}
+
+func TestPriorityQueue_Push(t *testing.T) {
+	heapSize := 3
+
+	// q item value will be [0, 1, 2]
+	q := setUpHeap(heapSize)
+
+	// Push function will push item to last
+	q.Push(&Item{
+		value:    3,
+		priority: 3,
+		index:    3,
+	})
+
+	assert.Equal(t, 3, q.Pop().(*Item).value)
+	assert.Equal(t, 2, q.Pop().(*Item).value)
+}
+
+func TestPriorityQueue_Swap(t *testing.T) {
+	heapSize := 3
+	q := setUpHeap(heapSize)
+
+	// Swap function swap two item(index i, index j)
+	q.Swap(0, 1)
+
+	assert.Equal(t, q[0].value, 1)
+	assert.Equal(t, q[1].value, 0)
+}

--- a/pbkstore.go
+++ b/pbkstore.go
@@ -16,62 +16,106 @@
 
 package swim
 
-import "sync"
+import (
+	"container/heap"
+	"errors"
+	"sync"
+)
 
-// PiggyBackData consists of data and localCount.
-// The localCount is incremented each time the data is queried.
-// The lower the localCount, the faster the queried.
+var ErrStoreEmpty = errors.New("empty store")
+var ErrPopInvalidType = errors.New("pop invalid typed item")
+
+const (
+	InitialPriority = 0
+)
+
+// PiggyBackStore store a piggyback data. When swim ping, ack or indirect-ack,
+// swim need to get PiggyBackData from the PiggyBackStore and send it with ping, ack or indirect-ack.
+
+// The priority is incremented each time when the data is queried.
+// The lower the priority, the faster the queried.
 // The data has a member status, such as alive, suspected or dead.
-type piggyBackData struct {
-	data       []byte
-	localCount int
-}
 
-// PiggyBackStore store a piggyback data. When we ping, ack or indirect-ack,
-// get PiggyBackData from the PiggyBackStore and send it with ping, ack or indirect-ack.
-type PiggyBackStore interface {
+type PBkStore interface {
 	Len() int
-	Push(b []byte) error
+	Push(b []byte)
 	Get() ([]byte, error)
 	IsEmpty() bool
 }
 
-// PiggyBackPriorityStore stores piggyback data and returns data with small local count.
-type PiggyBackPriorityStore struct {
-	list    []piggyBackData
-	maxSize int
-	lock    sync.RWMutex
+// PiggyBackStore stores piggyback data in the priority queue and returns data with smallest local count.
+type PriorityPBStore struct {
+	q             PriorityQueue
+	maxLocalCount int
+	lock          sync.RWMutex
 }
 
-func NewPiggyBackPriorityStore(maxSize int) *PiggyBackPriorityStore {
-	return &PiggyBackPriorityStore{
-		list:    make([]piggyBackData, 0),
-		maxSize: maxSize,
-		lock:    sync.RWMutex{},
+// macLocalCount is the max priority value
+func NewPriorityPBStore(maxLocalCount int) *PriorityPBStore {
+	return &PriorityPBStore{
+		q:             make(PriorityQueue, 0),
+		maxLocalCount: maxLocalCount,
+		lock:          sync.RWMutex{},
 	}
 }
 
 // Return current size of data
-func (p *PiggyBackPriorityStore) Len() int {
+func (p *PriorityPBStore) Len() int {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	return len(p.list)
+	return p.q.Len()
 }
 
 // Enqueue []byte into list.
 // Initially, set the local count to zero.
 // If the queue size is max, delete the data with the highest localcount and insert it.
-func (p *PiggyBackPriorityStore) Push(b []byte) error {
-	return nil
+func (p *PriorityPBStore) Push(pbkData []byte) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	item := &Item{
+		value:    pbkData,
+		priority: InitialPriority,
+	}
+
+	heap.Push(&p.q, item)
 }
 
 // Return the piggyback data with the smallest local count in the list,
 // increment the local count and sort it again, not delete the data.
-func (p *PiggyBackPriorityStore) Get() ([]byte, error) {
-	return nil, nil
+func (p *PriorityPBStore) Get() ([]byte, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	// Check empty
+	if len(p.q) == 0 {
+		return nil, ErrStoreEmpty
+	}
+
+	// Pop from queue
+	item := heap.Pop(&p.q).(*Item)
+	b, ok := item.value.([]byte)
+	if !ok {
+		return nil, ErrPopInvalidType
+	}
+
+	// If an item has been retrieved by maxPriority, remove it.
+	// If not, push it again after increment priority
+	item.priority = item.priority + 1
+	if item.priority < p.maxLocalCount {
+		p.q.Push(item)
+	}
+
+	return b, nil
 }
 
-func (p *PiggyBackPriorityStore) IsEmpty() bool {
-	return true
+func (p *PriorityPBStore) IsEmpty() bool {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if len(p.q) == 0 {
+		return true
+	}
+	return false
 }

--- a/pbkstore_internal_test.go
+++ b/pbkstore_internal_test.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package swim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPiggyBackPriorityStore(t *testing.T) {
+	pbkStore := NewPriorityPBStore(3)
+
+	assert.Equal(t, pbkStore.q.Len(), 0)
+	assert.Equal(t, pbkStore.maxLocalCount, 3)
+}

--- a/pbkstore_test.go
+++ b/pbkstore_test.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package swim_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/DE-labtory/swim"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPiggyBackPriorityStore_Push(t *testing.T) {
+
+	//given
+	pbkStore := swim.NewPriorityPBStore(3)
+
+	//when
+	pbkStore.Push([]byte("hello world"))
+	pbkStore.Push([]byte("hello world1"))
+
+	//then
+	assert.Equal(t, pbkStore.Len(), 2)
+}
+
+func TestPiggyBackPriorityStore_Get(t *testing.T) {
+
+	// given
+	pbkStore := swim.NewPriorityPBStore(3)
+	pbkStore.Push([]byte("hello world"))
+
+	// when
+	// When get function called, pbkstore internally increases the priority.
+	// First time
+	pbkData, err := pbkStore.Get()
+	assert.Nil(t, err)
+
+	// then
+	assert.Equal(t, pbkData, []byte("hello world"))
+	assert.Equal(t, pbkStore.Len(), 1)
+
+	// when
+	// Second time
+	pbkData_2, err := pbkStore.Get()
+	assert.Nil(t, err)
+
+	// then
+	assert.Equal(t, pbkData_2, []byte("hello world"))
+	assert.Equal(t, pbkStore.Len(), 1)
+
+	// when
+	// Third time
+	pbkData_3, err := pbkStore.Get()
+	assert.Nil(t, err)
+
+	// then
+	assert.Equal(t, pbkData_3, []byte("hello world"))
+
+	// This time data was queried three times, so it was deleted
+	assert.Equal(t, pbkStore.Len(), 0)
+
+	// when
+	_, err = pbkStore.Get()
+	assert.Equal(t, err, swim.ErrStoreEmpty)
+}
+
+func TestPiggyBackPriorityStore_Len(t *testing.T) {
+
+	// given
+	pbkStore := swim.NewPriorityPBStore(3)
+	for i := 0; i < 3; i++ {
+		pbkStore.Push([]byte(strconv.Itoa(i)))
+	}
+
+	// when && then
+	assert.Equal(t, pbkStore.Len(), 3)
+}
+
+func TestPiggyBackPriorityStore_IsEmpty(t *testing.T) {
+
+	// given
+	pbkStore := swim.NewPriorityPBStore(3)
+
+	// when && then
+	assert.True(t, pbkStore.IsEmpty())
+}


### PR DESCRIPTION
resolved: #48 

details:
Based on the `pbkStore interface`, I implemented interfaces.
PriorityPbkStore use priority queue based on localcount.
The smaller the `local count(priority)` is, the faster the query.

1. Create Priority queue based on local count(priority)
2. Implement Push, Len, Get, IsEmpty function

- [x] Test case