### PR TITLE
define Awareness model

### DIFF
--- a/awareness.go
+++ b/awareness.go
@@ -1,1 +1,46 @@
 package swim
+
+import (
+	"sync"
+	"time"
+)
+
+// Awareness manages health of the local node. This related to Lifeguard L1
+// "self-awareness" concept. Expect to receive replies to probe messages we sent
+// Start timeouts low, increase in response to absence of replies
+type Awareness struct {
+	sync.RWMutex
+
+	// max is the upper threshold for the factor that increase the timeout value
+	// (the score will be constrained from 0 <= score < max)
+	max uint
+
+	// score is the current awareness score. Lower values are healthier and
+	// zero is the minimum value
+	score uint
+}
+
+func NewAwareness(max uint) *Awareness {
+	return &Awareness{
+		max:   max,
+		score: 0,
+	}
+}
+
+func (a *Awareness) GetHealthScore() uint {
+	a.RLock()
+	defer a.RUnlock()
+	return a.score
+}
+
+// ApplyDelta with given delta applies it to the score in thread-safe manner
+// score must be bound from 0 to max value
+func (a *Awareness) ApplyDelta(delta int) {
+	return
+}
+
+// ScaleTimeout takes the given duration and scales it based on the current score.
+// Less healthyness will lead to longer timeouts.
+func (a *Awareness) ScaleTimeout(timeout time.Duration) time.Duration {
+	return timeout
+}


### PR DESCRIPTION
resolved: #46 

details:

From docs

> L1: Dynamic Fault Detector Timeouts: "Self-Awareness"
동적으로 Fault Detector timeout을 조정하는 것이다. 최초로 노드가 시작할 때는 failure detector timeout을 작게 잡고 시작한다. 그리고 내가 probe나 indirect probe를 날렸을 때 응답이 잘 안돌아오면 그에 따라서 timeout을 증가시킨다. 응답이 잘 안돌아오는 것을 자기 자신이 문제라고 생각하는 것이다. Failure detector timeout말고도 Probe Interval도 증가시킨다.
> #### Introduce Node Self-Awareness(NSA) counter
> self-awareness를 정량적으로 나타내고 그에 따라서 timeout, prove interval을 증가시키기 위해 NSA counter를 사용한다. NSA counter가 높을 수록 자기 자신 노드가 느리다고 생각하는 것이다.

define Awareness model