### PR TITLE
fix: dependency it-chain to de-labtory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,12 @@
 module github.com/DE-labtory/swim
 
 require (
-	github.com/btcsuite/btcutil v0.0.0-20180706230648-ab6388e0c60a // indirect
+	github.com/DE-labtory/heimdall v1.0.0
+	github.com/DE-labtory/iLogger v1.0.0
 	github.com/gogo/protobuf v1.1.1
 	github.com/golang/protobuf v1.2.0
-	github.com/it-chain/heimdall v0.2.4
-	github.com/it-chain/iLogger v0.0.0-20180921150123-3d4855e59818
 	github.com/rs/xid v1.2.1
-	github.com/sirupsen/logrus v1.2.0 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.3.0
 	github.com/urfave/cli v1.20.0
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 	golang.org/x/tools v0.0.0-20181120234846-b5f2cae84da8 // indirect

--- a/keyring.go
+++ b/keyring.go
@@ -3,10 +3,10 @@ package swim
 import (
 	"os"
 
-	"github.com/it-chain/heimdall"
-	"github.com/it-chain/heimdall/config"
-	"github.com/it-chain/heimdall/hecdsa"
-	"github.com/it-chain/iLogger"
+	"github.com/DE-labtory/heimdall"
+	"github.com/DE-labtory/heimdall/config"
+	"github.com/DE-labtory/heimdall/hecdsa"
+	"github.com/DE-labtory/iLogger"
 )
 
 /*

--- a/member_map.go
+++ b/member_map.go
@@ -24,8 +24,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DE-labtory/iLogger"
 	"github.com/DE-labtory/swim/pb"
-	"github.com/it-chain/iLogger"
 )
 
 var ErrEmptyMemberID = errors.New("MemberID is empty")

--- a/message_endpoint.go
+++ b/message_endpoint.go
@@ -21,9 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DE-labtory/iLogger"
 	"github.com/DE-labtory/swim/pb"
 	"github.com/gogo/protobuf/proto"
-	"github.com/it-chain/iLogger"
 )
 
 var ErrSendTimeout = errors.New("Error send timeout")

--- a/swim.go
+++ b/swim.go
@@ -26,8 +26,8 @@ import (
 
 	"sync/atomic"
 
+	"github.com/DE-labtory/iLogger"
 	"github.com/DE-labtory/swim/pb"
-	"github.com/it-chain/iLogger"
 	"github.com/rs/xid"
 )
 

--- a/util.go
+++ b/util.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"sync/atomic"
 
-	"github.com/it-chain/iLogger"
+	"github.com/DE-labtory/iLogger"
 )
 
 type status = int32


### PR DESCRIPTION
resolved: #120 

details:
- fix it-chain/heimdall to de-labtory/heimdall
- fix it-chain/ilogger to de-labtory/heimdall
- fix dependency it-chain to de-labtory in go.mod


- [x] Test case